### PR TITLE
Don't automatically stop the worker when all tests are done (fix compat with `ember-cli-code-coverage@v1`)

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -2,7 +2,6 @@ import { assert } from '@ember/debug';
 import { buildASTSchema, graphql } from 'graphql';
 import merge from 'lodash.merge';
 import { graphql as mswGraphql, setupWorker } from 'msw';
-import { done as qunitDone } from 'qunit';
 
 const IS_TESTEM = Boolean(window.Testem);
 const DEFAULT_OPTIONS = {
@@ -25,7 +24,6 @@ export function setupEmberGraphqlMocking(schemaDocument, providedOptions) {
 
   createWorker(options);
   createGraphqlOperationHandler(schemaDocument);
-  qunitDone(destroyWorker);
 }
 
 export function setupGraphqlTest(hooks) {
@@ -47,16 +45,16 @@ export function getWorker() {
   return worker;
 }
 
+export function destroyWorker() {
+  worker.stop();
+
+  worker = null;
+}
+
 function createWorker(options) {
   worker = setupWorker();
 
   worker.start(options.mswStartOptions);
-}
-
-function destroyWorker() {
-  worker.stop();
-
-  worker = null;
 }
 
 function createGraphqlOperationHandler(schemaDocument) {

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "ember-cli-babel": "^7.26.11",
     "graphql": "^16.3.0",
     "lodash.merge": "^4.6.2",
-    "msw": "0.36.7",
-    "qunit": "^2.17.2"
+    "msw": "0.36.7"
   },
   "devDependencies": {
     "@commitlint/cli": "^16.1.0",
@@ -79,6 +78,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.5.1",
+    "qunit": "^2.17.2",
     "qunit-dom": "^2.0.0",
     "release-it": "^14.2.1",
     "release-it-lerna-changelog": "^4.0.1",


### PR DESCRIPTION
There seems to be a racing condition between stopping the worker and `ember-cli-code-coverage@v1` executing its `/write-coverage` call. Keeping the worker alive after the tests are done, fixes this for now.

Closes #23.