### PR TITLE
Make `setupEmberGraphqlMocking` async

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ ember install @bagaar/ember-graphql-mocking
 In `tests/test-helper.js`:
 1. Import `setupEmberGraphqlMocking`
 2. Import your GraphQL schema
-3. Call `setupEmberGraphqlMocking` with `QUnit` and your GraphQL schema, _before_ calling `start`
+3. Call `setupEmberGraphqlMocking` with your GraphQL schema
 
 ```javascript
 // tests/test-helper.js
@@ -39,24 +39,28 @@ import { start } from 'ember-qunit';
 import { setupEmberGraphqlMocking } from '@bagaar/ember-graphql-mocking/test-support'; // 1.
 import schema from 'my-app/graphql/schema'; // 2.
 
+QUnit.begin(() => setupEmberGraphqlMocking(schema)); // 3.
+
 setApplication(Application.create(config.APP));
 
 setup(QUnit.assert);
 
-setupEmberGraphqlMocking(QUnit, schema); // 3.
-
 start();
 ```
+
+> **NOTE:** Make sure to use `QUnit.begin`, as `setupEmberGraphqlMocking` returns a Promise.
 
 If you want to pass along additional [start options](https://mswjs.io/docs/api/setup-worker/start#options)
 to MSW's service worker, you can do so by defining an `mswStartOptions` object:
 
 ```js
-setupEmberGraphqlMocking(QUnit, schema, {
-  mswStartOptions: {
-    // Additional MSW start options...
-  },
-});
+QUnit.begin(() =>
+  setupEmberGraphqlMocking(schema, {
+    mswStartOptions: {
+      // Additional MSW start options...
+    },
+  })
+);
 ```
 
 ### 2. Write an Acceptance Test

--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -19,19 +19,13 @@ let isSetupGraphqlTestCalled = false;
 let root = null;
 let worker = null;
 
-export function setupEmberGraphqlMocking(
-  QUnit,
-  schemaDocument,
-  providedOptions
-) {
+export function setupEmberGraphqlMocking(schemaDocument, providedOptions) {
   const options = merge({}, DEFAULT_OPTIONS, providedOptions);
 
-  QUnit.begin(() => {
-    createWorker();
-    createGraphqlOperationHandler(schemaDocument);
+  createWorker();
+  createGraphqlOperationHandler(schemaDocument);
 
-    return startWorker(options.mswStartOptions);
-  });
+  return startWorker(options.mswStartOptions);
 }
 
 export function setupGraphqlTest(hooks) {
@@ -80,7 +74,7 @@ function createGraphqlOperationHandler(schemaDocument) {
 }
 
 function startWorker(mswStartOptions) {
-  worker.start(mswStartOptions);
+  return worker.start(mswStartOptions);
 }
 
 function clearRoot() {

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,16 +1,21 @@
+import {
+  destroyWorker,
+  setupEmberGraphqlMocking,
+} from '@bagaar/ember-graphql-mocking/test-support';
+import { setApplication } from '@ember/test-helpers';
 import Application from 'dummy/app';
 import config from 'dummy/config/environment';
-import * as QUnit from 'qunit';
-import { setApplication } from '@ember/test-helpers';
-import { setup } from 'qunit-dom';
-import { start } from 'ember-qunit';
-import { setupEmberGraphqlMocking } from '@bagaar/ember-graphql-mocking/test-support';
 import schema from 'dummy/graphql/schema';
+import { start } from 'ember-qunit';
+import * as QUnit from 'qunit';
+import { setup } from 'qunit-dom';
+
+QUnit.begin(() => setupEmberGraphqlMocking(schema));
+
+QUnit.done(() => destroyWorker());
 
 setApplication(Application.create(config.APP));
 
 setup(QUnit.assert);
-
-setupEmberGraphqlMocking(QUnit, schema);
 
 start();


### PR DESCRIPTION
This way, the returned promise can be awaited using `QUnit.begin`,
making sure MSW is fully set up before running any tests.